### PR TITLE
remove ability to call torch compile until it is fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
 
 setup(
     name="aihandler",
-    version="1.10.3",
+    version="1.10.4",
     author="Capsize LLC",
     description="AI Handler: An engine which wraps certain huggingface models",
     long_description=open("README.md", "r", encoding="utf-8").read(),

--- a/src/aihandler/runner.py
+++ b/src/aihandler/runner.py
@@ -731,9 +731,10 @@ class SDRunner(BaseRunner):
             torch.save(self.pipe.unet.state_dict(), os.path.join(file_path, "unet.pt"))
 
     def apply_torch_compile(self):
-        if self.use_torch_compile:
-            logger.debug("Compiling torch model")
-            self.pipe.unet = torch.compile(self.pipe.unet)
+        return
+        # if self.use_torch_compile:
+        #     logger.debug("Compiling torch model")
+        #     self.pipe.unet = torch.compile(self.pipe.unet)
         # load unet state_dict from disc
         # file_path = os.path.join(os.path.join(self.model_base_path, self.model_path, "compiled"))
         # if os.path.exists(file_path):


### PR DESCRIPTION
torch compile doesn't work as expected after building the project - removing until a later date.